### PR TITLE
Fix overflow exception caused by incorrect type conversion in ComputeOffset

### DIFF
--- a/Noisrev.League.IO.RST/Helpers/OffsetHelper.cs
+++ b/Noisrev.League.IO.RST/Helpers/OffsetHelper.cs
@@ -24,6 +24,6 @@ public static class OffsetHelper
     /// <exception cref="OverflowException"/>
     public static ulong ComputeOffset(this long offset, RType type)
     {
-        return Convert.ToUInt64(offset << (byte)type);
+        return (ulong)offset << (byte)type;
     }
 }


### PR DESCRIPTION
See #8